### PR TITLE
fix(JHU lat long): handle empty lat long

### DIFF
--- a/covid19-etl/etl/jhu.py
+++ b/covid19-etl/etl/jhu.py
@@ -162,6 +162,8 @@ class JHU(base.BaseETL):
         `submitter_id` to check)
 
         Args:
+            file_type (str): type of this file - one
+                of ["global", "US_counties"]
             data_type (str): type of the data in this file - one
                 of ["confirmed", "deaths", "recovered"]
             url (str): URL at which the CSV file is available
@@ -220,6 +222,10 @@ class JHU(base.BaseETL):
         Converts a row of a CSV file to data we can submit via Sheepdog
 
         Args:
+            file_type (str): type of this file - one
+                of ["global", "US_counties"]
+            data_type (str): type of the data in this file - one
+                of ["confirmed", "deaths", "recovered"]
             headers (list(str)): CSV file headers (first row of the file)
             row (list(str)): row of data
 
@@ -234,8 +240,8 @@ class JHU(base.BaseETL):
 
         country = row[header_to_column["country"]]
         province = row[header_to_column["province"]]
-        latitude = row[header_to_column["latitude"]]
-        longitude = row[header_to_column["longitude"]]
+        latitude = row[header_to_column["latitude"]] or "0"
+        longitude = row[header_to_column["longitude"]] or "0"
 
         if country == "US" and province == "":
             # We are using US data by state instead of global


### PR DESCRIPTION

### Bug Fixes
- JHU ETL doesn't crash when the data contains empty values for latitude and longitude. We don't submit this data