### PR TITLE
update vctrs version

### DIFF
--- a/covid19-notebooks/jhu_map/jhu_map.Rmd
+++ b/covid19-notebooks/jhu_map/jhu_map.Rmd
@@ -10,7 +10,7 @@ If you need to install these libraries, uncomment and run this cell:
 
 ```{r setup, include=TRUE, message=FALSE}
 install.packages("https://cran.rstudio.com/src/contrib/rlang_0.4.6.tar.gz", repos=NULL)
-install.packages("https://cran.rstudio.com/src/contrib/vctrs_0.3.0.tar.gz", repos=NULL)
+install.packages("https://cran.rstudio.com/src/contrib/vctrs_0.3.1.tar.gz", repos=NULL)
 install.packages("https://cran.rstudio.com/src/contrib/tidyselect_1.1.0.tar.gz", repos=NULL)
 install.packages("https://cran.rstudio.com/bin/macosx/el-capitan/contrib/3.5/lifecycle_0.2.0.tgz", repos=NULL)
 devtools::install_github("tidyverse/tidyr")


### PR DESCRIPTION
Jira Ticket: [COV-100](https://occ-data.atlassian.net/browse/COV-100)
### Dependency updates
vctrs 0.3.0 was deprecated, replace with 0.3.1 in the JHU map R notebook.