### PR TITLE
IDPH query guppy

### DIFF
--- a/covid19-etl/etl/__init__.py
+++ b/covid19-etl/etl/__init__.py
@@ -1,9 +1,11 @@
 from importlib import import_module
 from pathlib import Path
 
-__all__ = [
-    import_module(f".{f.stem}", __package__)
-    for f in Path(__file__).parent.glob("*.py")
-    if "__" not in f.stem
-]
+__all__ = []
+for f in Path(__file__).parent.glob("*.py"):
+    if "__" not in f.stem:
+        try:
+            __all__.append(import_module(f".{f.stem}", __package__))
+        except Exception:
+            print(f"Unable to import module {f.stem} - skipping it")
 del import_module, Path

--- a/covid19-etl/etl/jhu_country_codes.py
+++ b/covid19-etl/etl/jhu_country_codes.py
@@ -47,7 +47,6 @@ class JHU_COUNTRY_CODES(base.BaseETL):
 
     def get_existing_locations(self):
         print("Getting summary_location data from Peregrine")
-        headers = {"Authorization": "bearer " + self.access_token}
         query_string = (
             '{ summary_location (first: 0, project_id: "'
             + self.program_name
@@ -55,19 +54,5 @@ class JHU_COUNTRY_CODES(base.BaseETL):
             + self.project_code
             + '") { submitter_id, country_region, iso2, iso3 } }'
         )
-        response = requests.post(
-            "{}/api/v0/submission/graphql".format(self.base_url),
-            json={"query": query_string, "variables": None},
-            headers=headers,
-        )
-        assert (
-            response.status_code == 200
-        ), "Unable to query Peregrine for existing 'summary_location' data: {}\n{}".format(
-            response.status_code, response.text
-        )
-        try:
-            query_res = json.loads(response.text)
-        except:
-            print("Peregrine did not return JSON")
-            raise
+        query_res = self.metadata_helper.query_peregrine(query_string)
         return [location for location in query_res["data"]["summary_location"]]

--- a/covid19-etl/etl/ncbi_file.py
+++ b/covid19-etl/etl/ncbi_file.py
@@ -210,7 +210,7 @@ class NCBI_FILE(base.BaseETL):
         """
 
         query_string = "{ " + node_name + " (first:0) { submitter_id } }"
-        response = await self.metadata_helper.query_node_data(query_string)
+        response = await self.metadata_helper.query_peregrine_async(query_string)
         records = response["data"][node_name]
         return set([record["submitter_id"] for record in records])
 

--- a/covid19-etl/etl/ncbi_file.py
+++ b/covid19-etl/etl/ncbi_file.py
@@ -210,7 +210,7 @@ class NCBI_FILE(base.BaseETL):
         """
 
         query_string = "{ " + node_name + " (first:0) { submitter_id } }"
-        response = await self.metadata_helper.query_peregrine_async(query_string)
+        response = await self.metadata_helper.async_query_peregrine(query_string)
         records = response["data"][node_name]
         return set([record["submitter_id"] for record in records])
 

--- a/covid19-etl/utils/metadata_helper.py
+++ b/covid19-etl/utils/metadata_helper.py
@@ -96,7 +96,7 @@ class MetadataHelper:
         Queries Guppy for the existing `location` data.
         Returns the latest submitted date as Python "datetime.date"
         """
-        print("Getting latest date from Guppy...")
+        print("Getting the latest date from Guppy...")
         query_string = """query ($filter: JSON) {
             location (
                 filter: $filter,
@@ -182,7 +182,7 @@ class MetadataHelper:
             print(f"Peregrine did not return JSON: {response.text}")
             raise
 
-    async def query_peregrine_async(self, query_string):
+    async def async_query_peregrine(self, query_string):
         async def _post_request(headers, query_string):
             url = f"{self.base_url}/api/v0/submission/graphql"
             async with ClientSession() as session:


### PR DESCRIPTION
Jira Ticket: COV-500

- fix failing jobs because `atlas.py` cannot be imported (`gen3` and `pandas` dependencies not in Dockerfile)
- refactor `jhu_country_codes` and `jhu` to use `query_peregrine` function
- all `idph` ETLs get the latest date from Guppy instead of Peregrine to avoid failures due to timeouts

### Bug Fixes
- Fix IDPH ETL failures due to timeouts
