### PR TITLE
JHU query Guppy

### DIFF
--- a/covid19-etl/etl/ds4c.py
+++ b/covid19-etl/etl/ds4c.py
@@ -10,7 +10,7 @@ CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 def harmonize_gender(gender):
-    {"male": "Male", "female": "Female", "": "Not reported"}[gender]
+    return {"male": "Male", "female": "Female", "": "Not reported"}[gender]
 
 
 class DS4C(base.BaseETL):

--- a/covid19-etl/etl/dsci.py
+++ b/covid19-etl/etl/dsci.py
@@ -11,7 +11,7 @@ CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 def harmonize_gender(gender):
-    {"male": "Male", "female": "Female", "": "Not reported"}[gender]
+    return {"male": "Male", "female": "Female", "": "Not reported"}[gender]
 
 
 def format_date(date):

--- a/covid19-etl/etl/idph.py
+++ b/covid19-etl/etl/idph.py
@@ -1,6 +1,5 @@
 import datetime
 import os
-import re
 from contextlib import closing
 
 import requests

--- a/covid19-etl/etl/idph_zipcode.py
+++ b/covid19-etl/etl/idph_zipcode.py
@@ -1,6 +1,5 @@
 from contextlib import closing
 import datetime
-import re
 import requests
 
 from etl import base

--- a/covid19-etl/etl/jhu_country_codes.py
+++ b/covid19-etl/etl/jhu_country_codes.py
@@ -1,9 +1,6 @@
 # This only needs to be run once, when new locations are submitted.
 # The country data was obtained from https://datahub.io/core/country-codes.
 
-import json
-import requests
-
 from etl import base
 from utils.metadata_helper import MetadataHelper
 from utils.country_codes_utils import get_codes_dictionary, get_codes_for_country_name

--- a/covid19-etl/etl/jhu_to_s3.py
+++ b/covid19-etl/etl/jhu_to_s3.py
@@ -7,7 +7,6 @@ from datetime import datetime
 import json
 import os
 import pathlib
-import re
 import requests
 import time
 

--- a/covid19-etl/etl/vac_tracker.py
+++ b/covid19-etl/etl/vac_tracker.py
@@ -1,5 +1,3 @@
-import csv
-import re
 from contextlib import closing
 
 import requests

--- a/covid19-etl/utils/async_file_helper.py
+++ b/covid19-etl/utils/async_file_helper.py
@@ -70,7 +70,6 @@ class AsyncFileHelper:
                 async with ClientSession() as session:
                     async with session.put(url, data=data) as r:
                         return r.status
-                return None
 
         basename = path.name
         presigned_url, guid = await self.async_get_presigned_url(basename)

--- a/covid19-etl/utils/format_helper.py
+++ b/covid19-etl/utils/format_helper.py
@@ -16,7 +16,8 @@ def format_submitter_id(node, args):
     """
     submitter_id = node
     for v in args.values():
-        submitter_id += "_{}".format(v)
+        if v:
+            submitter_id += "_{}".format(v)
 
     submitter_id = submitter_id.lower()
     submitter_id = re.sub("[^a-z0-9-_]+", "-", submitter_id)

--- a/covid19-notebooks/dashboard_charts/generate_plots.py
+++ b/covid19-notebooks/dashboard_charts/generate_plots.py
@@ -1,11 +1,6 @@
-import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
-import seaborn as sns
-import gen3
 from gen3.auth import Gen3Auth
 from gen3.submission import Gen3Submission
-import itertools
 from itertools import islice
 from collections import deque
 import plotly.graph_objects as go
@@ -17,7 +12,6 @@ raw_data_confirmed = pd.read_csv(confirmed_cases_data_url)
 data_day = (
     raw_data_confirmed.groupby(["Country/Region"]).sum().drop(["Lat", "Long"], axis=1)
 )
-df = data_day.transpose()
 data = data_day.reset_index().melt(id_vars="Country/Region", var_name="date")
 
 # Pivot data to wide & index by date

--- a/covid19-notebooks/generate_top10_plots.py
+++ b/covid19-notebooks/generate_top10_plots.py
@@ -1,6 +1,4 @@
-import numpy as np
 import pandas as pd
-import itertools
 from itertools import islice
 from collections import deque
 
@@ -10,7 +8,6 @@ raw_data_confirmed = pd.read_csv(confirmed_cases_data_url)
 data_day = (
     raw_data_confirmed.groupby(["Country/Region"]).sum().drop(["Lat", "Long"], axis=1)
 )
-df = data_day.transpose()
 data = data_day.reset_index().melt(id_vars="Country/Region", var_name="date")
 
 # Pivot data to wide & index by date


### PR DESCRIPTION
Jira Ticket: COV-524

- fix lgtm alerts
- fix 'none' in IDPH-Facility submitter_ids
- `jhu` ETL gets the latest data from Guppy instead of Peregrine to avoid failures due to timeouts. We only have the latest `summary_clinical` data in ES, so we can't get the list of all submitter_ids. Instead, get the latest submitted date and assume everything older than that has already been submitted for all locations <= might backfire if some locations get data for a date before others, but it's not the case atm

### Bug Fixes
- Fix JHU ETL failures due to timeouts

