### PR TITLE
Add Bayes model Mariner workflow

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade 'pip<20.3'
         pip install -r covid19-etl-requirements.txt
         pip install -r test-requirements.txt
         pip install pytest~=3.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/cdis/python:3.8-slim-buster
 RUN apt update && apt install -y vim
 
 COPY covid19-etl-requirements.txt ./covid19-etl-requirements.txt
-RUN pip3 install --upgrade pip==20.1.*
+RUN pip3 install --upgrade 'pip<20.3'
 RUN pip3 install -r covid19-etl-requirements.txt
 
 COPY ./covid19-etl /covid19-etl

--- a/covid19-etl/etl/bayes_model_workflow.py
+++ b/covid19-etl/etl/bayes_model_workflow.py
@@ -10,7 +10,7 @@ class BAYES_MODEL_WORKFLOW(base.BaseETL):
     def __init__(self, base_url, access_token, s3_bucket):
         super().__init__(base_url, access_token, s3_bucket)
         self.headers = {"Authorization": f"Bearer {access_token}"}
-        self.api_key = get_api_key(base_url, headers=self.headers)
+        self.api_key = None
 
         self.model_version = "v3.2"
         self.status_ping_minutes = 10
@@ -39,6 +39,8 @@ class BAYES_MODEL_WORKFLOW(base.BaseETL):
         return resp_data["status"]
 
     def files_to_submissions(self):
+        self.api_key = get_api_key(base_url, headers=self.headers)
+
         print("Preparing request body")
         url = f"https://raw.githubusercontent.com/uc-cdis/covid19model/{self.model_version}/cwl/request_body.json"
         r = requests.get(url)

--- a/covid19-etl/etl/bayes_model_workflow.py
+++ b/covid19-etl/etl/bayes_model_workflow.py
@@ -6,7 +6,7 @@ from etl import base
 from utils.fence_helper import get_api_key, get_access_token
 
 
-class MARINER_WORKFLOW(base.BaseETL):
+class BAYES_MODEL_WORKFLOW(base.BaseETL):
     def __init__(self, base_url, access_token, s3_bucket):
         super().__init__(base_url, access_token, s3_bucket)
         self.headers = {"Authorization": f"Bearer {access_token}"}

--- a/covid19-etl/etl/jhu.py
+++ b/covid19-etl/etl/jhu.py
@@ -128,10 +128,8 @@ class JHU(base.BaseETL):
                 },
             },
         }
-        (
-            self.existing_summary_locations,
-            self.last_date,
-        ) = self.metadata_helper.get_existing_data_jhu()
+        self.existing_summary_locations = []
+        self.last_date = ""
 
     def files_to_submissions(self):
         """
@@ -149,6 +147,11 @@ class JHU(base.BaseETL):
                 "deaths": "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_deaths_US.csv",
             },
         }
+
+        (
+            self.existing_summary_locations,
+            self.last_date,
+        ) = self.metadata_helper.get_existing_data_jhu()
 
         for file_type in ["global", "US_counties"]:
             for data_type, url in urls[file_type].items():

--- a/covid19-etl/etl/mariner_workflow.py
+++ b/covid19-etl/etl/mariner_workflow.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+import requests
+import time
+
+from etl import base
+
+
+class MARINER_WORKFLOW(base.BaseETL):
+    def __init__(self, base_url, access_token, s3_bucket):
+        super().__init__(base_url, access_token, s3_bucket)
+        self.headers = {"Authorization": f"Bearer {access_token}"}
+
+        self.model_version = "v3.2"
+        self.status_ping_minutes = 10
+
+    def get_status(self, run_id):
+        url = f"{self.base_url}/ga4gh/wes/v1/runs/{run_id}/status"
+        r = requests.get(url, headers=self.headers)
+        assert (
+            r.status_code == 200
+        ), f"Could not get run status from Mariner ({r.status_code}):\n{r.text}"
+        resp_data = r.json()
+        assert (
+            resp_data and "status" in resp_data
+        ), f"Mariner did not return a status:\n{resp_data}"
+        return resp_data["status"]
+
+    def files_to_submissions(self):
+        print("Preparing request body")
+        url = f"https://raw.githubusercontent.com/uc-cdis/covid19model/{self.model_version}/cwl/request_body.json"
+        r = requests.get(url)
+        assert r.status_code == 200, f"Could not get request body from {url}"
+        request_body = r.json()
+
+        request_body["input"]["s3_bucket"] = self.s3_bucket
+
+        # for testing - TODO remove
+        request_body["input"]["deathsCutoff"] = "7300"
+        request_body["input"]["maxBatchSize"] = "3"
+
+        print("Starting workflow run")
+        url = f"{self.base_url}/ga4gh/wes/v1/runs"
+        r = requests.post(url, json=request_body, headers=self.headers)
+        assert (
+            r.status_code == 200
+        ), f"Could not start Mariner workflow ({r.status_code}):\n{r.text}"
+        resp_data = r.json()
+        assert (
+            resp_data and "runID" in resp_data
+        ), f"Mariner did not return a runID:\n{resp_data}"
+        run_id = resp_data["runID"]
+
+        print(f"Monitoring workflow run (run ID: {run_id})")
+        time.sleep(10)  # Mariner might take a few seconds to start the run
+        status = "running"
+        while status in ["not-started", "running", "unknown"]:
+            status = self.get_status(run_id)
+            print(f"  [{datetime.now()}] status: {status}")
+            time.sleep(60 * self.status_ping_minutes)

--- a/covid19-etl/etl/mariner_workflow.py
+++ b/covid19-etl/etl/mariner_workflow.py
@@ -34,7 +34,7 @@ class MARINER_WORKFLOW(base.BaseETL):
         assert r.status_code == 200, f"Could not get request body from {url}"
         request_body = r.json()
 
-        request_body["input"]["s3_bucket"] = f"{s3://self.s3_bucket}"
+        request_body["input"]["s3_bucket"] = f"s3://{self.s3_bucket}"
 
         # for testing - TODO remove
         request_body["input"]["deathsCutoff"] = "7300"

--- a/covid19-etl/etl/mariner_workflow.py
+++ b/covid19-etl/etl/mariner_workflow.py
@@ -33,12 +33,7 @@ class MARINER_WORKFLOW(base.BaseETL):
         r = requests.get(url)
         assert r.status_code == 200, f"Could not get request body from {url}"
         request_body = r.json()
-
         request_body["input"]["s3_bucket"] = f"s3://{self.s3_bucket}"
-
-        # for testing - TODO remove
-        request_body["input"]["deathsCutoff"] = "7300"
-        request_body["input"]["maxBatchSize"] = "3"
 
         print("Starting workflow run")
         url = f"{self.base_url}/ga4gh/wes/v1/runs"

--- a/covid19-etl/etl/mariner_workflow.py
+++ b/covid19-etl/etl/mariner_workflow.py
@@ -34,7 +34,7 @@ class MARINER_WORKFLOW(base.BaseETL):
         assert r.status_code == 200, f"Could not get request body from {url}"
         request_body = r.json()
 
-        request_body["input"]["s3_bucket"] = self.s3_bucket
+        request_body["input"]["s3_bucket"] = f"{s3://self.s3_bucket}"
 
         # for testing - TODO remove
         request_body["input"]["deathsCutoff"] = "7300"

--- a/covid19-etl/tests/test_import.py
+++ b/covid19-etl/tests/test_import.py
@@ -1,7 +1,6 @@
 from importlib import import_module
 import os
 from pathlib import Path
-from requests.exceptions import RequestException
 
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -26,14 +25,9 @@ def test_import():
         etl_module = import_module(f"etl.{job_module}")
         etl = getattr(etl_module, job_class)
 
-        try:
-            job = etl(
-                base_url="fake_url", access_token="fake_token", s3_bucket="fake_bucket"
-            )
-        except RequestException:
-            # we could mock `requests` calls instead
-            pass
-
+        job = etl(
+            base_url="fake_url", access_token="fake_token", s3_bucket="fake_bucket"
+        )
         assert hasattr(
             job, "files_to_submissions"
         ), f"ETL {job_name} is missing files_to_submissions() method"

--- a/covid19-etl/utils/fence_helper.py
+++ b/covid19-etl/utils/fence_helper.py
@@ -1,0 +1,25 @@
+import requests
+
+
+def get_api_key(base_url, access_token=None, headers=None):
+    assert bool(access_token) ^ bool(
+        headers
+    ), "Must specify either 'access_token' or 'headers'"
+    if not headers:
+        headers = {"Authorization": f"Bearer {access_token}"}
+
+    url = f"{base_url}/user/credentials/api"
+    r = requests.post(url, json={"scope": ["openid", "user", "data"]}, headers=headers)
+    assert (
+        r.status_code == 200 and "api_key" in r.json()
+    ), f"Could not get an API key from Fence ({r.status_code}):\n{r.text}"
+    return r.json()["api_key"]
+
+
+def get_access_token(base_url, api_key):
+    url = f"{base_url}/user/credentials/api/access_token"
+    r = requests.post(url, json={"api_key": api_key})
+    assert (
+        r.status_code == 200 and "access_token" in r.json()
+    ), f"Could not get a new access token from Fence ({r.status_code}):\n{r.text}"
+    return r.json()["access_token"]


### PR DESCRIPTION
Jira Ticket: COV-558

- we don't need to update "serviceAccountName" in the request body because the SA name is the same in qa-covid19 and PRC prod. If we need it later, we can add it to [the job](https://github.com/uc-cdis/cloud-automation/blob/5729a13536e85e3c77f144d8922c034348724dce/kube/services/jobs/covid19-etl-job.yaml#L13)'s environment variables:
```
       - name: SERVICE_ACCOUNT_NAME
         valueFrom:
            fieldRef:
              fieldPath: spec.serviceAccountName
```

### New Features
- Add Bayes model Mariner workflow as an ETL that can be run on a cronjob
