### PR TITLE
JHU to S3 ETL: process "Unassigned" data 

### DIFF
--- a/covid19-etl/etl/jhu_to_s3.py
+++ b/covid19-etl/etl/jhu_to_s3.py
@@ -373,11 +373,6 @@ class JHU_TO_S3(base.BaseETL):
                 of ["confirmed", "deaths", "recovered"]
             headers (list(str)): CSV file headers (first row of the file)
             row (list(str)): row of data
-
-        Returns:
-            (dict, dict) tuple:
-                - location data, in a format ready to be submitted to Sheepdog
-                - { "date1": <value>, "date2": <value> } from the row data
         """
         if not row:  # ignore empty rows
             return
@@ -390,10 +385,12 @@ class JHU_TO_S3(base.BaseETL):
         latitude = row[header_to_column["latitude"]] or "0"
         longitude = row[header_to_column["longitude"]] or "0"
 
+        # Data with "Out of <state>" or "Unassigned" county value have
+        # unknown coordinates of (0,0). We keep them to have accurate counts,
+        # but they should not be displayed on the map: remove coordinates.
         if int(float(latitude)) == 0 and int(float(longitude)) == 0:
-            # Data with "Out of <state>" or "Unassigned" county value have
-            # unknown coordinates of (0,0). We don't submit them for now
-            return None, None
+            latitude = None
+            longitude = None
 
         codes = get_codes_for_country_name(self.codes_dict, country)
         iso3 = codes["iso3"]
@@ -774,6 +771,7 @@ class JHU_TO_S3(base.BaseETL):
 
         for data_level in ["country", "state", "county"]:
             print("  Uploading {} files".format(data_level.capitalize()))
+            i = 0
             for location_id, data_by_date in tmp[data_level].items():
                 # remove values smaller than the threshold
                 for date, data in data_by_date.items():
@@ -785,6 +783,9 @@ class JHU_TO_S3(base.BaseETL):
                 )
 
                 # write to local file, upload to S3, delete local file
+                if data_level == "county" and i % 100 == 0:
+                    print(f"    {i} / {len(tmp[data_level])}")
+                i += 1
                 with open(abs_path, "w") as f:
                     json.dump(data_by_date, f)
                 s3_path = os.path.relpath(abs_path, CURRENT_DIR)

--- a/covid19-etl/utils/country_codes_utils.py
+++ b/covid19-etl/utils/country_codes_utils.py
@@ -22,6 +22,9 @@ ISO_CODES_MAPPING = {
     # ISO codes for countries that are not in the CSV file
     "Kosovo": {"iso2": "XK", "iso3": "XKX"},
     "West Bank and Gaza": {"iso2": "PS", "iso3": "PSE"},
+    # JHU has data for boats - we want to include them in total counts
+    "Diamond Princess": {"iso2": "Diamond Princess", "iso3": "Diamond Princess"},
+    "MS Zaandam": {"iso2": "MS Zaandam", "iso3": "MS Zaandam"},
 }
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION

### Improvements
- JHU to S3 ETL: process "Unassigned" county data instead of ignoring it to get more accurate global counts
