### PR TITLE
NCBI-manifest ETL: fix asyncio error

### DIFF
--- a/covid19-etl/etl/ncbi.py
+++ b/covid19-etl/etl/ncbi.py
@@ -341,7 +341,7 @@ class NCBI(base.BaseETL):
                 retrying = False
             except Exception as e:
                 print(
-                    f"Can not query peregine with {node_name}. Detail {e}. Retrying ..."
+                    f"Can not query peregine with {node_name}. Detail {e}. Retrying..."
                 )
 
         for accession_number in submitting_accession_numbers:
@@ -440,7 +440,7 @@ class NCBI(base.BaseETL):
                     retrying = False
                 except Exception as e:
                     print(
-                        f"ERROR: Fail to query indexd for {filename}. Detail {e}. Retrying ..."
+                        f"ERROR: Fail to query indexd for {filename}. Detail {e}. Retrying..."
                     )
                     await asyncio.sleep(5)
 
@@ -457,7 +457,7 @@ class NCBI(base.BaseETL):
                     except Exception as e:
                         tries += 1
                         print(
-                            f"ERROR: Fail to update indexd for {filename}. Detail {e}. Retrying ..."
+                            f"ERROR: Fail to update indexd for {filename}. Detail {e}. Retrying..."
                         )
                         await asyncio.sleep(5)
 
@@ -692,7 +692,7 @@ class NCBI(base.BaseETL):
                 retrying = False
             except Exception as e:
                 print(
-                    f"ERROR: Fail to get indexd for {filename}. Detail {e}. Retrying ..."
+                    f"ERROR: Fail to get indexd for {filename}. Detail {e}. Retrying..."
                 )
                 await asyncio.sleep(5)
 
@@ -710,7 +710,7 @@ class NCBI(base.BaseETL):
                     break
                 except Exception as e:
                     print(
-                        f"ERROR: Fail to update indexd for {filename}. Detail {e}. Retrying ..."
+                        f"ERROR: Fail to update indexd for {filename}. Detail {e}. Retrying..."
                     )
                     retries += 1
                     await asyncio.sleep(5)

--- a/covid19-etl/etl/ncbi_file.py
+++ b/covid19-etl/etl/ncbi_file.py
@@ -286,7 +286,7 @@ class NCBI_FILE(base.BaseETL):
                 retrying = False
             except Exception as e:
                 print(
-                    f"ERROR: Fail to query indexd for {filename}. Detail {e}. Retrying ..."
+                    f"ERROR: Fail to query indexd for {filename}. Detail {e}. Retrying..."
                 )
                 await asyncio.sleep(5)
 
@@ -299,7 +299,7 @@ class NCBI_FILE(base.BaseETL):
                     retrying = False
                 except Exception as e:
                     print(
-                        f"ERROR: Fail to upload file {filepath}. Detail {e}. Retrying ..."
+                        f"ERROR: Fail to upload file {filepath}. Detail {e}. Retrying..."
                     )
                     await asyncio.sleep(5)
         else:

--- a/covid19-etl/etl/ncbi_manifest.py
+++ b/covid19-etl/etl/ncbi_manifest.py
@@ -81,7 +81,7 @@ class NCBI_MANIFEST(base.BaseETL):
                     if row_num < last_row_num:
                         continue
                     if row_num % 1000 == 0:
-                        print(f"Proccessed {row_num} rows of {key}")
+                        print(f"Processed {row_num} rows of {key}")
                     words = line.split("\t")
                     guid = conform_data_format(words[0].strip(), "guid")
                     size = int(conform_data_format(words[2].strip(), "size"))
@@ -105,7 +105,9 @@ class NCBI_MANIFEST(base.BaseETL):
             loop.run_until_complete(
                 asyncio.gather(self.index_manifest(self.sra_src_manifest))
             )
-            loop.run_until_complete(asyncio.gather(AsyncFileHelper.close_session()))
+            future = AsyncFileHelper.close_session()
+            if future:
+                loop.run_until_complete(asyncio.gather(future))
 
         finally:
             loop.close()
@@ -147,7 +149,7 @@ class NCBI_MANIFEST(base.BaseETL):
                         retrying = False
                     except Exception as e:
                         print(
-                            f"ERROR: Fail to query indexd for {filename}. Detail {e}. Retrying ..."
+                            f"ERROR: Fail to query indexd for {filename}. Detail {e}. Retrying..."
                         )
                         await asyncio.sleep(5)
 
@@ -166,7 +168,7 @@ class NCBI_MANIFEST(base.BaseETL):
                     except Exception as e:
                         retries += 1
                         print(
-                            f"ERROR: Fail to create new indexd record for {guid}. Detail {e}. Retrying ..."
+                            f"ERROR: Fail to create new indexd record for {guid}. Detail {e}. Retrying..."
                         )
                         await asyncio.sleep(5)
 


### PR DESCRIPTION
Fix error:
```
Traceback (most recent call last):
  File "/covid19-etl/main.py", line 33, in <module>
    job.submit_metadata()
  File "/covid19-etl/etl/ncbi_manifest.py", line 108, in submit_metadata
    loop.run_until_complete(asyncio.gather(AsyncFileHelper.close_session()))
  File "/usr/local/lib/python3.8/asyncio/tasks.py", line 821, in gather
    fut = ensure_future(arg, loop=loop)
  File "/usr/local/lib/python3.8/asyncio/tasks.py", line 681, in ensure_future
    raise TypeError('An asyncio.Future, a coroutine or an awaitable is '
TypeError: An asyncio.Future, a coroutine or an awaitable is required
```

### Bug Fixes
- NCBI-manifest ETL: fix asyncio error
