### PR TITLE
Files for new covid19-notebook-etl job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# This is the Dockerfile for the "covid19-etl" job.
+
 FROM quay.io/cdis/python:3.8-slim-buster
 
 RUN apt update && apt install -y vim

--- a/covid19-notebooks/Dockerfile
+++ b/covid19-notebooks/Dockerfile
@@ -1,3 +1,10 @@
+# DEPRECATED
+# This is an old Dockerfile for the "nb-etl" (renamed "covid19-nb-etl") job.
+#
+# The Bayes model is not run by this job anymore, but we keep this Dockerfile,
+# the "run-with-slack.sh" and "nb-etl-run.sh" scripts, and the
+# "bayes-by-county" folder until we're ready to delete them.
+
 FROM quay.io/cdis/debian:bullseye
 
 # install R dependencies

--- a/covid19-notebooks/covid19-notebook-etl-Dockerfile
+++ b/covid19-notebooks/covid19-notebook-etl-Dockerfile
@@ -1,0 +1,25 @@
+# This is the Dockerfile for the "covid19-notebook-etl" job.
+
+FROM quay.io/cdis/debian:bullseye
+
+WORKDIR /nb-etl
+
+# install Python dependencies
+RUN apt-get update && apt-get install -y \
+	python3 \
+	python3-pip \
+	python3-pandas \
+	python3-matplotlib \
+	python3-numpy \
+	python3-scipy
+
+COPY ./nb-etl-requirements.txt /nb-etl/
+RUN pip3 install -r nb-etl-requirements.txt
+RUN pip3 install awscli==1.18.*
+
+# copy Python notebooks
+COPY ./seir-forecast/seir-forecast.ipynb /nb-etl/
+COPY ./generate_top10_plots.py /nb-etl/
+
+COPY ./nb-etl-run.sh ./covid19-notebook-etl-run-with-slack.sh /nb-etl/
+CMD [ "bash", "/nb-etl/covid19-notebook-etl-run-with-slack.sh" ]

--- a/covid19-notebooks/covid19-notebook-etl-run-with-slack.sh
+++ b/covid19-notebooks/covid19-notebook-etl-run-with-slack.sh
@@ -1,0 +1,16 @@
+if ! bash "/nb-etl/covid19-notebook-etl-run.sh"; then
+    echo "JOBFAIL: covid19-notebook-etl-job"
+    if [[ -n "$slackWebHook" && "$doSlack" == "true" ]]; then
+        echo "Posting failed message to slack.."
+        payload="{\"attachments\": [{\"fallback\": \"JOBFAIL: covid19-notebook-etl job on ${gen3Env}\",\"color\": \"#ff0000\",\"pretext\": \"JOBFAIL: covid19-notebook-etl job on ${gen3Env}\",\"author_name\": \"Pod name: ${HOSTNAME}\",\"title\": \"COVID19-NOTEBOOK-ETL JOB FAILED\",\"text\": \"JOBFAIL: covid19-notebook-etl job on ${gen3Env}\",\"ts\": "$(date +%s)"}]}"
+        echo "${payload}"
+        curl -X POST --data-urlencode "payload=${payload}" "${slackWebHook}"
+    fi
+else
+    echo "JOBSUCCESS: covid19-notebook-etl-job"
+    if [[ -n "$slackWebHook" && "$doSlack" == "true" ]]; then
+        echo "Posting success message to slack.."
+        payload="{\"attachments\": [{\"fallback\": \"JOBSUCCESS: covid19-notebook-etl job on ${gen3Env}\",\"color\": \"#2EB67D\",\"pretext\": \"JOBFAIL: covid19-notebook-etl job on ${gen3Env}\",\"author_name\": \"Pod name: ${HOSTNAME}\",\"title\": \"COVID19-NOTEBOOK-ETL JOB SUCCEDED :tada:\",\"text\": \"JOBSUCCESS: covid19-notebook-etl job on ${gen3Env}\",\"ts\": \"$(date +%s)\"}]}"
+        curl -X POST --data-urlencode "payload=${payload}" "${slackWebHook}"
+    fi
+fi

--- a/covid19-notebooks/covid19-notebook-etl-run.sh
+++ b/covid19-notebooks/covid19-notebook-etl-run.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# run Python notebooks and push outputs to S3
+
+# ===> commenting out `seir-forecast` - broken and unsused
+# FILE="seir-forecast.ipynb"
+# if [ ! -f $FILE ]; then
+#   echo "$FILE not exist. Exiting..."
+#   exit 1
+# fi
+# echo "Running notebook $FILE..."
+# jupyter nbconvert --to notebook --inplace --execute "$FILE"
+
+echo "Running top10 script..."
+python3 generate_top10_plots.py
+
+echo "Copying to S3 bucket..."
+if [[ -n "$S3_BUCKET" ]]; then
+#   aws s3 cp "simulated_cases.txt" "$S3_BUCKET/simulated_cases.txt"
+#   aws s3 cp "observed_cases.txt" "$S3_BUCKET/observed_cases.txt"
+  aws s3 cp "top10.txt" "$S3_BUCKET/top10.txt"
+fi


### PR DESCRIPTION
Jira Ticket: [COV-807](https://occ-data.atlassian.net/browse/COV-807)

Goes with https://github.com/uc-cdis/cloud-automation/pull/1556

### New Features
- Make copies of the "nb-etl" Dockerfile and scripts; rename them "covid19-notebook-etl" and remove sections relevant to the Bayes model. The old files will stay here until we can completely deprecate the "nb-etl" job, which runs the Bayes model. The new "covid19-notebook-etl" job only runs notebooks.

### Deployment changes
- Deploy the new job by adding `covid19-notebook-etl` to the manifest versions block
