### PR TITLE
Fix "NoneType object is not iterable" error

### DIFF
--- a/covid19-etl/etl/idph_vaccine.py
+++ b/covid19-etl/etl/idph_vaccine.py
@@ -193,7 +193,7 @@ class IDPH_VACCINE(IDPH):
                 illinois_summary_clinical_submitter_id = summary_clinical_submitter_id
 
             for k in ["Age", "Race", "Gender"]:
-                data = county_demo_data.get(k)
+                data = county_demo_data.get(k, [])
                 for item in data:
                     keys, props = self.parse_group_clinical_demographic(
                         county_demo_mapping, item


### PR DESCRIPTION
Fix:
```
File "/covid19-etl/etl/idph_vaccine.py", line 138, in parse_link
File "/covid19-etl/etl/idph_vaccine.py", line 197, in parse_county_data
    for item in data:
TypeError: 'NoneType' object is not iterable
FAIL: covid19-etl-idph_vaccine failure in chicagoland.pandemicresponsecommons.org
```

### Bug Fixes
- IDPH-Vaccine ETL: Fix "NoneType object is not iterable" error
