### PR TITLE
NCBI ETL improvements

### DIFF
--- a/covid19-etl/etl/load_virus_metadata.py
+++ b/covid19-etl/etl/load_virus_metadata.py
@@ -1,3 +1,6 @@
+# DEPRECATED
+
+from datetime import datetime
 import glob
 import hashlib
 from os import path

--- a/covid19-etl/etl/ncbi_manifest.py
+++ b/covid19-etl/etl/ncbi_manifest.py
@@ -1,10 +1,10 @@
 import asyncio
+import csv
 from pathlib import Path
 import re
 import json
 import requests
 import time
-import datetime
 from dateutil.parser import parse
 
 from botocore import UNSIGNED
@@ -17,11 +17,14 @@ from utils.async_file_helper import AsyncFileHelper
 from utils.metadata_helper import MetadataHelper
 
 
-MAX_RETRIES = 5
+MAX_RETRIES = 4
 
 
-def conform_data_format(data, field_name):
+def validate_sra_value_format(row_num, field_name, value):
     """function to check if the data is in right format"""
+    if field_name in ["file_name", "authz", "release_date"]:
+        return value
+
     if field_name == "guid":
         pattern = (
             "dg.63D5/[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$"
@@ -34,10 +37,10 @@ def conform_data_format(data, field_name):
         pattern = "[a-z0-9]{32}$"
     else:
         raise Exception(f"There is no {field_name}")
-    if re.match(pattern, data):
-        return data
+    if re.match(pattern, value):
+        return value
     raise Exception(
-        f"Wrong format for {field_name}. Expect {data} has the format of {pattern}"
+        f"SRA manifest: Wrong format for '{field_name}' (row #{row_num}). Expected value to match '{pattern}' but got '{value}'"
     )
 
 
@@ -45,12 +48,10 @@ class NCBI_MANIFEST(base.BaseETL):
     def __init__(self, base_url, access_token, s3_bucket):
         super().__init__(base_url, access_token, s3_bucket)
 
-        self.manifest_bucket = "sra-pub-sars-cov2"
-        self.sra_src_manifest = "sra-src/Manifest"
         self.program_name = "open"
         self.project_code = "ncbi-covid-19"
         self.token = access_token
-        self.last_submission_identifier = None
+        self.last_submitted_guid = None
 
         self.file_helper = AsyncFileHelper(
             base_url=self.base_url,
@@ -66,34 +67,49 @@ class NCBI_MANIFEST(base.BaseETL):
             access_token=access_token,
         )
 
-    def read_ncbi_manifest(self, key):
-        """read the manifest"""
+    def format_ncbi_sra_row(self, row_num, row, headers):
+        validated_data = []
+        for i, field_name in enumerate(headers):
+            if field_name == "authz":
+                value = f"/programs/{self.program_name}/project/{self.project_code}"
+            else:
+                value = validate_sra_value_format(row_num, field_name, row[i].strip())
+            if field_name == "size":
+                value = int(value)
+            elif field_name == "release_date":
+                value = parse(re.sub(r":[0-9]{3}", "", value))
+            validated_data.append(value)
+        return validated_data
+
+    def read_ncbi_sra_manifest(self):
+        sra_s3_bucket = "sra-pub-sars-cov2"
+        sra_manifest = "sra-src/Manifest"
+        print(f"Reading SRA manifest 's3://{sra_s3_bucket}/{sra_manifest}'...")
+        headers = ["guid", "file_name", "size", "md5", "authz", "url", "release_date"]
         tries = 0
+        row_num = 0
         last_row_num = 0
-        while tries < MAX_RETRIES:
+        while tries <= MAX_RETRIES:
             try:
                 s3 = boto3.resource("s3", config=Config(signature_version=UNSIGNED))
-                s3_object = s3.Object(self.manifest_bucket, key)
+                s3_object = s3.Object(sra_s3_bucket, sra_manifest)
                 line_stream = codecs.getreader("utf-8")
-                row_num = 0
-                for line in line_stream(s3_object.get()["Body"]):
-                    row_num = row_num + 1
+                input = line_stream(s3_object.get()["Body"])
+                reader = csv.reader(input, delimiter="\t")
+                for row_num, row in enumerate(reader):
                     if row_num < last_row_num:
                         continue
-                    if row_num % 1000 == 0:
-                        print(f"Processed {row_num} rows of {key}")
-                    words = line.split("\t")
-                    guid = conform_data_format(words[0].strip(), "guid")
-                    size = int(conform_data_format(words[2].strip(), "size"))
-                    md5 = conform_data_format(words[3].strip(), "md5")
-                    authz = f"/programs/{self.program_name}/project/{self.project_code}"
-                    url = conform_data_format(words[5].strip(), "url")
-                    release_date = parse(re.sub(r":[0-9]{3}", "", words[6].strip()))
-                    yield guid, size, md5, authz, url, release_date
-                break
+                    if row_num % 10000 == 0 and row_num != 0:
+                        print(f"Processed {row_num} rows")
+                    yield self.format_ncbi_sra_row(row_num, row, headers)
+                break  # done reading the manifest!
             except Exception as e:
-                print(f"Can not stream {key}. Retrying...")
+                print(
+                    f"Failed to stream 's3://{sra_s3_bucket}/sra_manifest' (try #{tries}). Retrying... Details:\n{e}"
+                )
                 time.sleep(30)
+                if tries == MAX_RETRIES:
+                    raise e
                 tries += 1
                 last_row_num = row_num
 
@@ -102,19 +118,19 @@ class NCBI_MANIFEST(base.BaseETL):
 
         loop = asyncio.get_event_loop()
         try:
-            loop.run_until_complete(
-                asyncio.gather(self.index_manifest(self.sra_src_manifest))
-            )
-            future = AsyncFileHelper.close_session()
-            if future:
-                loop.run_until_complete(asyncio.gather(future))
-
+            loop.run_until_complete(asyncio.gather(self.process_sra_manifest()))
         finally:
-            loop.close()
+            try:
+                if AsyncFileHelper.session:
+                    future = AsyncFileHelper.close_session()
+                    if future:
+                        loop.run_until_complete(asyncio.gather(future))
+            finally:
+                loop.close()
         end = time.strftime("%X")
         print(f"Running time: From {start} to {end}")
 
-    async def index_manifest(self, manifest):
+    async def process_sra_manifest(self):
         query_string = (
             '{ project (first: 0, dbgap_accession_number: "'
             + self.project_code
@@ -122,56 +138,81 @@ class NCBI_MANIFEST(base.BaseETL):
         )
         try:
             response = self.metadata_helper.query_peregrine(query_string)
-            self.last_submission_identifier = parse(
-                response["data"]["project"][0]["last_submission_identifier"]
-            )
+            self.last_submitted_guid = response["data"]["project"][0][
+                "last_submission_identifier"
+            ]
         except Exception as ex:
-            self.last_submission_identifier = None
+            print(f"Error getting 'last_submission_identifier': {ex}")
+            self.last_submitted_guid = None
+        print(
+            f"Last submitted GUID ('last_submission_identifier'): {self.last_submitted_guid}"
+        )
+        seen_last_submitted_guid = False
+        failed = False
 
-        now = datetime.datetime.now()
-        last_submission_date_time = now.strftime("%m/%d/%Y, %H:%M:%S")
-
-        for (guid, size, md5, authz, url, release_date) in self.read_ncbi_manifest(
-            manifest
-        ):
+        for (
+            guid,
+            filename,
+            size,
+            md5,
+            authz,
+            url,
+            release_date,
+        ) in self.read_ncbi_sra_manifest():
             if (
-                not self.last_submission_identifier
-                or release_date > self.last_submission_identifier
+                not self.last_submitted_guid  # no data was ever submitted yet
+                or not seen_last_submitted_guid  # this data is not already indexed
             ):
-                filename = url.split("/")[-1]
-                retrying = True
-
-                while retrying:
+                retries = 0
+                file_is_indexed = False
+                while retries <= MAX_RETRIES:
                     try:
-                        did, _, _, _, _, _ = await self.file_helper.async_find_by_name(
-                            filename
+                        file_is_indexed = (
+                            await self.file_helper.async_indexd_record_exists(guid)
                         )
-                        retrying = False
+                        break
                     except Exception as e:
                         print(
-                            f"ERROR: Fail to query indexd for {filename}. Detail {e}. Retrying..."
+                            f"ERROR: Fail to query indexd for {guid} (try #{retries}). Retrying... Details:\n{e}"
                         )
+                        if retries == MAX_RETRIES:
+                            failed = True
+                        retries += 1
                         await asyncio.sleep(5)
 
-                if did:
-                    print(f"{filename} was already indexed")
+                if file_is_indexed:
+                    print(f"{filename} ({guid}) is already indexed")
                     continue
 
-                print(f"start to index {filename}")
+                print(f"start to index {filename} ({guid})")
                 retries = 0
-                while retries < MAX_RETRIES:
+                while retries <= MAX_RETRIES:
                     try:
                         await self.file_helper.async_index_record(
                             guid, size, filename, url, authz, md5
                         )
                         break
                     except Exception as e:
-                        retries += 1
                         print(
-                            f"ERROR: Fail to create new indexd record for {guid}. Detail {e}. Retrying..."
+                            f"ERROR: Fail to create new indexd record for {guid} (try #{retries}). Retrying... Details:\n{e}"
                         )
+                        if retries == MAX_RETRIES:
+                            failed = True
+                        retries += 1
                         await asyncio.sleep(5)
 
+            if failed:
+                # stop processing the manifest, but don't exit because we
+                # need to record the `last_submission_identifier`
+                break
+
+            # found the last submitted data! start indexing on the next row
+            if guid == self.last_submitted_guid:
+                seen_last_submitted_guid == True
+
+        # update the project's `last_submission_identifier` so that next
+        # time we can skip processing the rows we just processed
+        print(f"Updating project's 'last_submission_identifier' to '{guid}'")
         headers = {
             "content-type": "application/json",
             "Authorization": f"Bearer {self.access_token}",
@@ -179,10 +220,11 @@ class NCBI_MANIFEST(base.BaseETL):
         record = {
             "code": self.project_code,
             "dbgap_accession_number": self.project_code,
-            "last_submission_identifier": last_submission_date_time,
+            "last_submission_identifier": guid,  # last GUID we indexed
         }
         res = requests.put(
             "{}/api/v0/submission/{}".format(self.base_url, self.program_name),
             headers=headers,
             data=json.dumps(record),
         )
+        res.raise_for_status()

--- a/covid19-etl/utils/async_file_helper.py
+++ b/covid19-etl/utils/async_file_helper.py
@@ -3,7 +3,7 @@ import requests
 
 
 class AsyncFileHelper:
-    """ Asynchronous file helper class"""
+    """Asynchronous file helper class"""
 
     session = None
 
@@ -23,6 +23,21 @@ class AsyncFileHelper:
     def close_session(cls):
         if cls.session is not None:
             return cls.session.close()
+
+    async def async_get_indexd_record(self, guid):
+        url = f"{self.base_url}/index/index/{guid}"
+        session = AsyncFileHelper.get_session()
+        async with session.get(url) as r:
+            if r.status == 200:
+                return r.json()
+            elif r.status == 404:
+                return None
+            else:
+                r.raise_for_status()
+
+    async def async_indexd_record_exists(self, guid):
+        record = await self.async_get_indexd_record(guid)
+        return True if record else False
 
     async def async_find_by_name(self, filename):
         """Asynchronous call to fine the indexd record given a filename"""
@@ -46,7 +61,7 @@ class AsyncFileHelper:
             return None, None, None, None, "", None
 
     async def async_update_authz(self, did, rev):
-        """Asynchronous update authz field for did"""
+        """Asynchronous update authz field and remove uploader for did"""
 
         url = f"{self.base_url}/index/index/{did}?rev={rev}"
         session = AsyncFileHelper.get_session()

--- a/covid19-etl/utils/file_helper.py
+++ b/covid19-etl/utils/file_helper.py
@@ -19,6 +19,20 @@ class FileHelper:
         self.project_code = project_code
         self.headers = {"Authorization": f"Bearer {access_token}"}
 
+    def get_indexd_record(self, guid):
+        url = f"{self.base_url}/index/index/{guid}"
+        r = requests.get(url)
+        if r.status_code == 200:
+            return r.json()
+        elif r.status_code == 404:
+            return None
+        else:
+            r.raise_for_status()
+
+    def indexd_record_exists(self, guid):
+        record = self.get_indexd_record(guid)
+        return True if record else False
+
     def find_by_name(self, filename):
         url = f"{self.base_url}/index/index?file_name={filename}"
         r = requests.get(url)
@@ -35,6 +49,7 @@ class FileHelper:
         return None, None, None, None
 
     def update_authz(self, did, rev):
+        """Update authz field and remove uploader for did"""
         url = f"{self.base_url}/index/index/{did}?rev={rev}"
         body_json = {
             "authz": [f"/programs/{self.program_name}/projects/{self.project_code}"],


### PR DESCRIPTION
Jira Ticket: https://occ-data.atlassian.net/browse/COV-763

### Bug Fixes
- NCBI-manifest ETL: some files were not getting indexed because of the "last_submission_identifier" logic. Use the last processed row's GUID instead of `release_date` to check if data has already been indexed
- NCBI-manifest ETL: stop processing the manifest when we fail to index a file, so that we don't update the "last_submission_identifier" when we failed to index some files, or they will be skipped forever

### Improvements
- NCBI and NCBI-file ETLs: add comments
- NCBI-manifest ETL: add comments, add logs, refactor for readability 
