### PR TITLE
Update IDPH-zipcode URL and adapt ETL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 | --- | --- | --- | --- |
 | [COV-24][cov-24] | John Hopkins Data | [here][jhu] | Scheduled |
 | [COV-12][cov-12] | IDPH County-level data | ([JSON][idph-county-json]) | Scheduled |
-| [COV-79][cov-79] | IDPH Zipcode data| ([JSON][idph-zipcode-json]) | Scheduled |
+| [COV-79][cov-79] | IDPH Zipcode data| [here](https://dph.illinois.gov/covid19/data/data-portal/zip-level-tests-and-cases.html) | Scheduled |
 | [COV-273][cov-273] | IDPH Facility data | [here][idph-facility] ([JSON][idph-facility-json]) | Scheduled |
 | ~~[COV-345][cov-345]~~ | ~~IDPH Hospital data~~ | ~~[here][idph-hospital] ([JSON][idph-hospital-json])~~ | ~~Scheduled~~ |
 | [COV-1014][cov-1014] | IDPH Regional ICU Capacity | [here][idph-hospital] ([JSON][idph-regional-icu-cap-json]) | Scheduled |
@@ -136,7 +136,6 @@ covid19-tools
 [chi-nbhd-json]: https://covid19neighborhoods.southsideweekly.com/page-data/index/page-data.json
 [jhu]: https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data/csse_covid_19_time_series
 [idph-county-json]: http://www.dph.illinois.gov/sitefiles/COVIDTestResults.json?nocache=1
-[idph-zipcode-json]: http://dph.illinois.gov/sitefiles/COVIDZip.json?nocache=1
 [idph-facility]: https://dph.illinois.gov/covid19/long-term-care-facility-outbreaks-covid-19
 [idph-facility-json]: https://dph.illinois.gov/sitefiles/COVIDLTC.json?nocache=1
 [idph-hospital]: http://www.dph.illinois.gov/covid19/hospitalization-utilization


### PR DESCRIPTION
Jira Ticket: COV-1062

### Improvements
- IDPH-zipcode ETL: update the source data URLs and update the ETL to parse the new data format
- IDPH-zipcode ETL: process historical data since the last submitted date, instead of only the current day's data
