### PR TITLE
(COV-1079): Prevent duplicate record submission in `idph_hospitalization_etl`

### DIFF
--- a/covid19-etl/etl/idph_hospital_utilization.py
+++ b/covid19-etl/etl/idph_hospital_utilization.py
@@ -94,25 +94,25 @@ class IDPH_HOSPITAL_UTILIZATION(base.BaseETL):
                 "province_state": self.state,
             }
             self.summary_locations.append(summary_location)
-            processed_dates = set()
-            duplicate_records = False  # Added temporarily to identify an intermittent issue of duplicate records
+            first_util_date = None
             for utilization in data:
-                reported_date = utilization["ReportDate"]
                 if (
                     latest_submitted_date is None
-                    or get_date_from_str(reported_date) > latest_submitted_date
+                    or get_date_from_str(utilization["ReportDate"])
+                    > latest_submitted_date
                 ):
-                    if reported_date in processed_dates:
-                        duplicate_records = True
-                        print(f"Found duplicate record with date - {reported_date}")
                     summary_clinical = self.parse_historical(
                         summary_location_submitter_id, utilization
                     )
                     self.summary_clinicals.append(summary_clinical)
-                    processed_dates.add(utilization["ReportDate"])
 
-            if duplicate_records:
-                print(data)
+                # There is a known bug in IDPH API where the data records are repeated
+                # Since the dates are always sorted, we break the loop
+                # as soon as a repitition is noticed
+                if not first_util_date:
+                    first_util_date = data[0]["ReportDate"]
+                elif first_util_date == utilization["ReportDate"]:
+                    break
 
     def parse_historical(self, summary_location_submitter_id, utilization):
         utilization_mapping = {

--- a/covid19-etl/etl/idph_hospital_utilization.py
+++ b/covid19-etl/etl/idph_hospital_utilization.py
@@ -96,6 +96,7 @@ class IDPH_HOSPITAL_UTILIZATION(base.BaseETL):
             self.summary_locations.append(summary_location)
             processed_dates = set()
             duplicate_records = False  # Added temporarily to identify an intermittent issue of duplicate records
+            print(len(data["utilization"]))
             for utilization in data:
                 reported_date = utilization["ReportDate"]
                 if (
@@ -162,6 +163,7 @@ class IDPH_HOSPITAL_UTILIZATION(base.BaseETL):
         self.metadata_helper.batch_submit_records()
 
         print("Submitting summary_clinical data")
+        print(f"Length of summary_clinicals is {self.summary_clinicals}")
         for sc in self.summary_clinicals:
             sc_record = {"type": "summary_clinical"}
             sc_record.update(sc)

--- a/covid19-etl/etl/idph_hospital_utilization.py
+++ b/covid19-etl/etl/idph_hospital_utilization.py
@@ -98,7 +98,7 @@ class IDPH_HOSPITAL_UTILIZATION(base.BaseETL):
             for utilization in data:
                 # There is a known bug in IDPH API where the data records are repeated
                 # Since the dates are always sorted, we break the loop
-                # as soon as a repitition is noticed
+                # as soon as a repetition is noticed
                 if not first_util_date:
                     first_util_date = data[0]["ReportDate"]
                 elif first_util_date == utilization["ReportDate"]:
@@ -162,7 +162,6 @@ class IDPH_HOSPITAL_UTILIZATION(base.BaseETL):
         self.metadata_helper.batch_submit_records()
 
         print("Submitting summary_clinical data")
-        print(f"Length of summary_clinicals is {len(self.summary_clinicals)}")
         for sc in self.summary_clinicals:
             sc_record = {"type": "summary_clinical"}
             sc_record.update(sc)

--- a/covid19-etl/etl/idph_hospital_utilization.py
+++ b/covid19-etl/etl/idph_hospital_utilization.py
@@ -101,7 +101,7 @@ class IDPH_HOSPITAL_UTILIZATION(base.BaseETL):
                 if (
                     latest_submitted_date is None
                     or get_date_from_str(reported_date) > latest_submitted_date
-                ):  # TODO : Add logic to print the utilization records outside the loop if duplicates are found.
+                ):
                     if reported_date in processed_dates:
                         duplicate_records = True
                         print(f"Found duplicate record with date - {reported_date}")

--- a/covid19-etl/etl/idph_hospital_utilization.py
+++ b/covid19-etl/etl/idph_hospital_utilization.py
@@ -96,7 +96,7 @@ class IDPH_HOSPITAL_UTILIZATION(base.BaseETL):
             self.summary_locations.append(summary_location)
             processed_dates = set()
             duplicate_records = False  # Added temporarily to identify an intermittent issue of duplicate records
-            print(len(data["utilization"]))
+            print(len(data))
             for utilization in data:
                 reported_date = utilization["ReportDate"]
                 if (

--- a/covid19-etl/etl/idph_hospital_utilization.py
+++ b/covid19-etl/etl/idph_hospital_utilization.py
@@ -96,23 +96,6 @@ class IDPH_HOSPITAL_UTILIZATION(base.BaseETL):
             self.summary_locations.append(summary_location)
             first_util_date = None
             for utilization in data:
-                reported_date = utilization["ReportDate"]
-                if (
-                    latest_submitted_date is None
-                    or get_date_from_str(reported_date) > latest_submitted_date
-                ):
-                    if reported_date in processed_dates:
-                        duplicate_records = True
-                        print(f"Found duplicate record with date - {reported_date}")
-                    summary_clinical = self.parse_historical(
-                        summary_location_submitter_id, utilization
-                    )
-                    self.summary_clinicals.append(summary_clinical)
-                    processed_dates.add(utilization["ReportDate"])
-
-            if duplicate_records:
-                print(data)
-
                 # There is a known bug in IDPH API where the data records are repeated
                 # Since the dates are always sorted, we break the loop
                 # as soon as a repitition is noticed
@@ -120,6 +103,16 @@ class IDPH_HOSPITAL_UTILIZATION(base.BaseETL):
                     first_util_date = data[0]["ReportDate"]
                 elif first_util_date == utilization["ReportDate"]:
                     break
+
+                if (
+                    latest_submitted_date is None
+                    or get_date_from_str(utilization["ReportDate"])
+                    > latest_submitted_date
+                ):
+                    summary_clinical = self.parse_historical(
+                        summary_location_submitter_id, utilization
+                    )
+                    self.summary_clinicals.append(summary_clinical)
 
     def parse_historical(self, summary_location_submitter_id, utilization):
         utilization_mapping = {

--- a/covid19-etl/etl/idph_hospital_utilization.py
+++ b/covid19-etl/etl/idph_hospital_utilization.py
@@ -96,7 +96,6 @@ class IDPH_HOSPITAL_UTILIZATION(base.BaseETL):
             self.summary_locations.append(summary_location)
             processed_dates = set()
             duplicate_records = False  # Added temporarily to identify an intermittent issue of duplicate records
-            print(len(data))
             for utilization in data:
                 reported_date = utilization["ReportDate"]
                 if (
@@ -163,7 +162,7 @@ class IDPH_HOSPITAL_UTILIZATION(base.BaseETL):
         self.metadata_helper.batch_submit_records()
 
         print("Submitting summary_clinical data")
-        print(f"Length of summary_clinicals is {self.summary_clinicals}")
+        print(f"Length of summary_clinicals is {len(self.summary_clinicals)}")
         for sc in self.summary_clinicals:
             sc_record = {"type": "summary_clinical"}
             sc_record.update(sc)


### PR DESCRIPTION
Jira Ticket: [COV-1079](https://occ-data.atlassian.net/browse/COV-1079)

### Improvements
* Add a patch to overcome an intermittent bug in the [GetHospitalUtilizationResults API](https://idph.illinois.gov/DPHPublicInformation/api/COVIDExport/GetHospitalUtilizationResults) in `idph_hospitalization_etl` 
