### PR TITLE
Fix ETL: add 'Winter Olympics 2022'

### DIFF
--- a/covid19-etl/utils/country_codes_utils.py
+++ b/covid19-etl/utils/country_codes_utils.py
@@ -29,6 +29,10 @@ ISO_CODES_MAPPING = {
         "iso2": "Summer Olympics 2020",
         "iso3": "Summer Olympics 2020",
     },
+    "Winter Olympics 2022": {
+        "iso2": "Winter Olympics 2022",
+        "iso3": "Winter Olympics 2022",
+    },
 }
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
Fix error `Exception: Cannot find ISO codes data for "Winter Olympics 2022"` in JHU-country-codes ETL after the JHU ETL has submitted this new location

### Improvements
- Fix JHU-country-codes ETL: add 'Winter Olympics 2022' location
