### PR TITLE
IDPH-zipcode ETL: fewer guppy queries

### DIFF
--- a/covid19-etl/etl/ctp.py
+++ b/covid19-etl/etl/ctp.py
@@ -325,7 +325,7 @@ class CTP(base.BaseETL):
             if value and value.lower() not in ["nan", "n/a"]:
                 try:
                     summary_clinical[k] = int(value.replace(",", ""))
-                except:
+                except Exception:
                     pass
 
         dataQualityGrade = row[self.header_to_column["dataQualityGrade"]]

--- a/covid19-etl/etl/idph_zipcode.py
+++ b/covid19-etl/etl/idph_zipcode.py
@@ -43,21 +43,22 @@ class IDPH_ZIPCODE(base.BaseETL):
         print(
             f"Latest submitted date: {latest_submitted_date}. Getting data until date: {today}"
         )
+        existing_summary_locations = (
+            self.metadata_helper.get_existing_summary_locations()
+        )
         for i in range(int((today - latest_submitted_date).days)):
             date = latest_submitted_date + datetime.timedelta(i + 1)
-            self.parse_data(date.strftime("%Y-%m-%d"))
+            self.parse_data(date.strftime("%Y-%m-%d"), existing_summary_locations)
 
-    def parse_data(self, date_str):
+    def parse_data(self, date_str, existing_summary_locations):
         """
         Converts a JSON files to data we can submit via Sheepdog. Stores the
         records to submit in `self.summary_locations` and `self.summary_clinicals`.
 
         Args:
             date_str (str): date in "%Y-%m-%d" format
+            existing_summary_locations (list): [<location submitter_id>, ...]
         """
-        existing_summary_locations = (
-            self.metadata_helper.get_existing_summary_locations()
-        )
         url = f"https://idph.illinois.gov/DPHPublicInformation/api/COVIDExport/GetZip?reportDate={date_str}"
         print("Getting data from {}".format(url))
         with closing(self.get(url, stream=True)) as r:

--- a/covid19-etl/utils/metadata_helper.py
+++ b/covid19-etl/utils/metadata_helper.py
@@ -175,7 +175,7 @@ class MetadataHelper:
             raise
         try:
             return response.json()
-        except:
+        except Exception:
             print(f"Peregrine did not return JSON: {response.text}")
             raise
 
@@ -195,7 +195,7 @@ class MetadataHelper:
                         raise
                     try:
                         response = await response.json()
-                    except:
+                    except Exception:
                         print(f"Peregrine did not return JSON: {response.text}")
                         raise
                     return response
@@ -218,7 +218,7 @@ class MetadataHelper:
             raise
         try:
             return response.json()
-        except:
+        except Exception:
             print(f"Guppy did not return JSON: {response.status_code} {response.text}")
             raise
 
@@ -242,7 +242,7 @@ class MetadataHelper:
             raise
         try:
             return response.json()
-        except:
+        except Exception:
             print(f"Guppy did not return JSON: {response.status_code} {response.text}")
             raise
 
@@ -356,4 +356,7 @@ class MetadataHelper:
             )
 
         location_list = query_res["data"]["location"]
+        assert (
+            type(location_list) == list
+        ), f"Did not receive a list of locations from Guppy. Received: {query_res}"
         return [location["submitter_id"] for location in location_list]


### PR DESCRIPTION
Jira Ticket: COV-1118

fix intermittent issues querying guppy:
```
File "/covid19-etl/utils/metadata_helper.py", line 359, in get_existing_summary_locations
    return [location["submitter_id"] for location in location_list]
TypeError: 'NoneType' object is not iterable
```

```
...
Getting data from https://idph.illinois.gov/DPHPublicInformation/api/COVIDExport/GetZip?reportDate=2021-11-08
Getting current 'location' records from Guppy...
Getting data from https://idph.illinois.gov/DPHPublicInformation/api/COVIDExport/GetZip?reportDate=2021-11-09
Getting current 'location' records from Guppy...
Getting data from https://idph.illinois.gov/DPHPublicInformation/api/COVIDExport/GetZip?reportDate=2021-11-10
Getting current 'location' records from Guppy...
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/urllib3/connection.py", line 169, in _new_conn
    conn = connection.create_connection(
  File "/usr/local/lib/python3.8/site-packages/urllib3/util/connection.py", line 73, in create_connection
    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
  File "/usr/local/lib/python3.8/socket.py", line 918, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -3] Temporary failure in name resolution
```

### Improvements
- IDPH-zipcode ETL: fewer guppy queries
