### PR TITLE
Workflow to build `covid19-notebook-etl` image

### DIFF
--- a/.github/workflows/build_covid19-notebook-etl.yml
+++ b/.github/workflows/build_covid19-notebook-etl.yml
@@ -1,0 +1,35 @@
+name: Build covid19-notebook-etl
+
+on:
+  push:
+    paths:
+      - 'covid19-notebooks/**'
+
+jobs:
+  dockerBuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Extract branch name
+        id: extract_branch
+        shell: bash
+        # get the branch name, and replace "/" with "_"
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | tr / _)"
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./covid19-notebooks
+          file: ./covid19-notebooks/covid19-notebook-etl-Dockerfile
+          push: true
+          tags: quay.io/cdis/covid19-notebook-etl:${{ steps.extract_branch.outputs.branch }}
+          cache-from: type=registry,ref=quay.io/cdis/covid19-notebook-etl:${{ steps.extract_branch.outputs.branch }}
+          cache-to: type=inline


### PR DESCRIPTION
Jira Ticket: COV-1122

The `covid19-notebook-etl` image needs too much memory to build on Quay. Github workflows have a higher memory limit. This workflow currently takes ~20 min to run when there's no cache (i think every time there's a new branch), so only run it when the relevant files are updated.

### New Features
- Workflow to build `covid19-notebook-etl` image
