### PR TITLE
Update pymc3_generative_model.py

### DIFF
--- a/generative_bayes_model/pymc3_generative_model.py
+++ b/generative_bayes_model/pymc3_generative_model.py
@@ -327,9 +327,30 @@ with pm.Model() as model:
     y_logp = pm.Deterministic("y_logp", y_past.logpt)
 
 with model:
-    trace = pm.sample(
-        500, tune=800, chains=1, target_accept=0.95, random_seed=42, cores=8, init="adapt_diag"
-    )
+    try:
+        trace = pm.sample(
+            100, tune=100, chains=1, target_accept=0.95, random_seed=42, cores=1
+        )
+    except ValueError:
+        trace = pm.sample(
+            100,
+            tune=100,
+            chains=1,
+            target_accept=0.95,
+            random_seed=42,
+            cores=1,
+            init="adapt_diag",
+        )
+    else:
+        trace = pm.sample(
+            100,
+            tune=100,
+            chains=1,
+            target_accept=0.95,
+            random_seed=42,
+            cores=1,
+            init="advi+adapt_diag",
+        )
     pm.save_trace(trace=trace, directory="./trace", overwrite=True)
 
 with model:

--- a/generative_bayes_model/pymc3_generative_model.py
+++ b/generative_bayes_model/pymc3_generative_model.py
@@ -328,7 +328,7 @@ with pm.Model() as model:
 
 with model:
     trace = pm.sample(
-        500, tune=800, chains=1, target_accept=0.95, random_seed=42, cores=8
+        500, tune=800, chains=1, target_accept=0.95, random_seed=42, cores=8, init="adapt_diag"
     )
     pm.save_trace(trace=trace, directory="./trace", overwrite=True)
 


### PR DESCRIPTION

### Bug Fixes
add `init="adapt_diag"` to `pm.sample` to avoid the `Mass matrix contains zeros on the diagonal` error.

`jitter+adapt_diag` made initialization much more sensitive, causing ValueError: Mass matrix contains zeros on the diagonal to appear more frequently.



