### PR TITLE
update exception logic for sampling process

### DIFF
--- a/generative_bayes_model/pymc3_generative_model.py
+++ b/generative_bayes_model/pymc3_generative_model.py
@@ -331,26 +331,31 @@ with model:
         trace = pm.sample(
             100, tune=100, chains=1, target_accept=0.95, random_seed=42, cores=1
         )
-    except ValueError:
-        trace = pm.sample(
-            100,
-            tune=100,
-            chains=1,
-            target_accept=0.95,
-            random_seed=42,
-            cores=1,
-            init="adapt_diag",
-        )
-    else:
-        trace = pm.sample(
-            100,
-            tune=100,
-            chains=1,
-            target_accept=0.95,
-            random_seed=42,
-            cores=1,
-            init="advi+adapt_diag",
-        )
+    except ValueError as e:
+        logger.warning(f"Ran into ValueError, now trying adapt_diag. Details: {e}")
+        try:
+            trace = pm.sample(
+                100,
+                tune=100,
+                chains=1,
+                target_accept=0.95,
+                random_seed=42,
+                cores=1,
+                init="adapt_diag",
+            )
+        except Exception as e2:
+            logger.warning(
+                f"Ran into another exception, now trying advi+adapt_diag. Details: {e2}"
+            )
+            trace = pm.sample(
+                100,
+                tune=100,
+                chains=1,
+                target_accept=0.95,
+                random_seed=42,
+                cores=1,
+                init="advi+adapt_diag",
+            )
     pm.save_trace(trace=trace, directory="./trace", overwrite=True)
 
 with model:


### PR DESCRIPTION
### Improvements

- Update the exception logic for` pm.sample()` in the prediction part.

- Use 3 initialization methods to run prediction model:
1. default initialization method which is `jitter+adapt_diag`. It uses test value plus a uniform jitter in [-1, 1] as starting point in each chain.
2. `adapt_diag`: Start with a identity mass matrix and then adapt a diagonal based on the variance of the tuning samples. All chains use the test value (usually the prior mean) as starting point.
3. `advi+adapt_diag`: Run ADVI and then adapt the resulting diagonal mass matrix based on the sample variance of the tuning samples.