### PR TITLE
Fix cityofchicago ETL

### DIFF
--- a/covid19-etl/etl/cityofchicago.py
+++ b/covid19-etl/etl/cityofchicago.py
@@ -382,10 +382,14 @@ class CITYOFCHICAGO(base.BaseETL):
             {"country": self.country, "state": self.state, "city": self.city},
         )
 
-        self.last_submission_identifier = self.metadata_helper.get_last_submission()  # datetime
+        self.last_submission_identifier = (
+            self.metadata_helper.get_last_submission()
+        )  # datetime
 
         if self.last_submission_identifier:
-            self.last_submission_identifier = self.last_submission_identifier.strftime("%Y-%m-%d")
+            self.last_submission_identifier = self.last_submission_identifier.strftime(
+                "%Y-%m-%d"
+            )
         else:
             # for the first entry in dataset, which is from date `2020-03-01`
             self.last_submission_identifier = "2020-03-01"

--- a/covid19-etl/etl/idph.py
+++ b/covid19-etl/etl/idph.py
@@ -67,7 +67,7 @@ class IDPH(base.BaseETL):
         """
         start = time.time()
 
-        latest_submitted_date = self.metadata_helper.get_latest_submitted_date_idph()
+        latest_submitted_date = self.metadata_helper.get_latest_submitted_date()
         today = datetime.date.today()
         if latest_submitted_date == today:
             print("Nothing to submit: today and latest submitted date are the same.")

--- a/covid19-etl/etl/idph_facility.py
+++ b/covid19-etl/etl/idph_facility.py
@@ -38,7 +38,7 @@ class IDPH_FACILITY(IDPH):
         Reads JSON file and convert the data to Sheepdog records
         """
 
-        latest_submitted_date = self.metadata_helper.get_latest_submitted_date_idph()
+        latest_submitted_date = self.metadata_helper.get_latest_submitted_date()
         today = datetime.date.today()
         if latest_submitted_date == today:
             print("Nothing to submit: today and latest submitted date are the same.")

--- a/covid19-etl/etl/idph_hospital.py
+++ b/covid19-etl/etl/idph_hospital.py
@@ -44,7 +44,7 @@ class IDPH_HOSPITAL(base.BaseETL):
         Reads JSON file and convert the data to Sheepdog records
         """
 
-        latest_submitted_date = self.metadata_helper.get_latest_submitted_date_idph()
+        latest_submitted_date = self.metadata_helper.get_latest_submitted_date()
         today = datetime.date.today()
         if latest_submitted_date == today:
             print("Nothing to submit: today and latest submitted date are the same.")

--- a/covid19-etl/etl/idph_hospital_utilization.py
+++ b/covid19-etl/etl/idph_hospital_utilization.py
@@ -47,7 +47,7 @@ class IDPH_HOSPITAL_UTILIZATION(base.BaseETL):
         """
 
         today = datetime.date.today()
-        latest_submitted_date = self.metadata_helper.get_latest_submitted_date_idph()
+        latest_submitted_date = self.metadata_helper.get_latest_submitted_date()
         print(f"Latest submitted date from guppy is {str(latest_submitted_date)}")
         if latest_submitted_date == today:
             print("Nothing to submit: today and latest submitted date are the same.")

--- a/covid19-etl/etl/idph_regional_icu_capacity.py
+++ b/covid19-etl/etl/idph_regional_icu_capacity.py
@@ -44,7 +44,7 @@ class IDPH_REGIONAL_ICU_CAPACITY(base.BaseETL):
         """
 
         today = datetime.date.today()
-        latest_submitted_date = self.metadata_helper.get_latest_submitted_date_idph()
+        latest_submitted_date = self.metadata_helper.get_latest_submitted_date()
         if latest_submitted_date == today:
             print("Nothing to submit: today and latest submitted date are the same.")
             return

--- a/covid19-etl/etl/idph_vaccine.py
+++ b/covid19-etl/etl/idph_vaccine.py
@@ -62,7 +62,7 @@ class IDPH_VACCINE(IDPH):
         """
 
         # latest_submitted_date = (
-        #     self.metadata_helper.get_latest_submitted_date_idph()
+        #     self.metadata_helper.get_latest_submitted_date()
         # )
         # if latest_submitted_date != None and latest_submitted_date == self.date:
         #     print(

--- a/covid19-etl/etl/idph_zipcode.py
+++ b/covid19-etl/etl/idph_zipcode.py
@@ -34,7 +34,7 @@ class IDPH_ZIPCODE(base.BaseETL):
         Reads JSON file and convert the data to Sheepdog records
         """
 
-        latest_submitted_date = self.metadata_helper.get_latest_submitted_date_idph()
+        latest_submitted_date = self.metadata_helper.get_latest_submitted_date()
         today = datetime.date.today()
         if latest_submitted_date == today:
             print("Nothing to submit: today and latest submitted date are the same.")

--- a/covid19-etl/tests/test_cityofchicago.py
+++ b/covid19-etl/tests/test_cityofchicago.py
@@ -1,3 +1,4 @@
+from dateutil.parser import parse
 import os
 import csv
 from etl.cityofchicago import CITYOFCHICAGO
@@ -29,12 +30,12 @@ def get_test_etl():
         def get_existing_summary_locations(self):
             return []
 
-        def get_latest_submitted_date_idph(self):
+        def get_latest_submitted_date(self):
             return None
 
         def get_last_submission(self):
             # The following returns date for the first entry in dataset, which is `2020-03-01`
-            return "2020-03-01"
+            return parse("2020-03-01")
 
     etl = CITYOFCHICAGO("base_url", "access_token", "s3_bucket")
     etl.get = lambda *args, **kwargs: mock_get(args)

--- a/covid19-etl/utils/metadata_helper.py
+++ b/covid19-etl/utils/metadata_helper.py
@@ -73,12 +73,12 @@ class MetadataHelper:
 
         return summary_locations, latest_submitted_date
 
-    def get_latest_submitted_date_idph(self):
+    def get_latest_submitted_date(self):
         """
         Queries Guppy for the existing `location` data.
         Returns the latest submitted date as Python "datetime.date" in "%Y-%m-%d" format
         """
-        str_latest_submitted_date = self.get_str_latest_submitted_date_idph()
+        str_latest_submitted_date = self.get_str_latest_submitted_date()
         if str_latest_submitted_date is not None:
             latest_submitted_date = datetime.datetime.strptime(
                 str_latest_submitted_date, "%Y-%m-%d"
@@ -86,7 +86,7 @@ class MetadataHelper:
             return latest_submitted_date.date()
         return None
 
-    def get_str_latest_submitted_date_idph(self):
+    def get_str_latest_submitted_date(self):
         print("Getting the latest summary_clinical date from Guppy...")
         query_string = """query ($filter: JSON) {
             location (
@@ -252,6 +252,7 @@ class MetadataHelper:
             raise
 
     def get_last_submission(self):
+        """ Returns a datetime """
         query_string = (
             '{ project (first: 0, dbgap_accession_number: "'
             + self.project_code

--- a/covid19-etl/utils/metadata_helper.py
+++ b/covid19-etl/utils/metadata_helper.py
@@ -252,7 +252,7 @@ class MetadataHelper:
             raise
 
     def get_last_submission(self):
-        """ Returns a datetime """
+        """Returns a datetime"""
         query_string = (
             '{ project (first: 0, dbgap_accession_number: "'
             + self.project_code


### PR DESCRIPTION
Fix error:
```
Traceback (most recent call last):
  File "/covid19-etl/main.py", line 32, in <module>
    job.files_to_submissions()
  File "/covid19-etl/etl/cityofchicago.py", line 403, in files_to_submissions
    self.parse_cityofchicago_file(
  File "/covid19-etl/etl/cityofchicago.py", line 307, in parse_cityofchicago_file
    CITYOFCHICAGO_CDH_URL
TypeError: can only concatenate str (not "datetime.datetime") to str
```

### Bug Fixes
- Fix cityofchicago ETL bug when there is existing data
